### PR TITLE
HTTP cache for image

### DIFF
--- a/iOS-UtilKits/Classes/SessionManager.swift
+++ b/iOS-UtilKits/Classes/SessionManager.swift
@@ -19,7 +19,12 @@ public class SessionManager : NSObject {
     
     public static let session: URLSession =  {
         let configuration = URLSessionConfiguration.default
-        configuration.httpMaximumConnectionsPerHost = 4
+        let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        configuration.urlCache = URLCache(
+            memoryCapacity: 25 * 1024 * 1024,
+            diskCapacity: 200 * 1024 * 1024,
+            directory: cachesURL.appendingPathComponent("HTTPCache")
+        )
         return URLSession(
             configuration: configuration,
             delegate: sessionDelegate,


### PR DESCRIPTION
Add image cache feature by providing your own `URLCache` instance ([REF](https://stackoverflow.com/questions/48989552/large-image-url-response-not-cached-by-urlsession-why)) with larger capacity ([REF](https://stackoverflow.com/questions/20768968/why-is-nsurlsession-dont-use-my-configured-nsurlcache)).
